### PR TITLE
Support X-Api-Key Header 

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -249,7 +249,7 @@ func (c *client) upload(b []byte) error {
 	req.Header.Add("User-Agent", "analytics-go (version: "+Version+")")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Content-Length", string(len(b)))
-	req.SetBasicAuth(c.key, "")
+	req.Header.Add("x-api-key", c.key)
 
 	res, err := c.http.Do(req)
 

--- a/analytics.go
+++ b/analytics.go
@@ -239,7 +239,7 @@ func (c *client) send(msgs []message) {
 
 // Upload serialized batch message.
 func (c *client) upload(b []byte) error {
-	url := c.Endpoint + "/v1/batch"
+	url := c.Endpoint
 	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	if err != nil {
 		c.errorf("creating request - %s", err)


### PR DESCRIPTION
- Change authentication method from basic auth to `x-api-key` header.
-  Remove Hardcoded path from endpoint.

