### PR TITLE
DIN-28 Add sending metrics to DataDog or Log

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,50 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:8dbe0536c1cd5341268fd540b86e33851267e42a1311c4b729cd2162d4f69cac"
+  name = "github.com/FindHotel/meta"
+  packages = [
+    "pkg/env",
+    "pkg/log",
+    "pkg/reports",
+  ]
+  pruneopts = "UT"
+  revision = "a4d0708c5a22471f7b5bd950a291d75df8734fc5"
+
+[[projects]]
+  digest = "1:553f73a4171c265045ae4f5d3122429ecf2c9c0c232c91f336127fe45480104a"
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "62661b46c4093e2c1f38d943e663db1a29873e80"
+  version = "v2.1.0"
+
+[[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d38f81081a389f1466ec98192cf9115a82158854d6f01e1c23e2e7554b97db71"
+  name = "github.com/rcrowley/go-metrics"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3113b8401b8a98917cde58f8bbd42a1b1c03b1fd"
+
+[[projects]]
   digest = "1:e271becdebd3dd7c004d7977a15ebdd1f4fa19f2fa7122d13e1116e9444a3190"
   name = "github.com/segmentio/analytics-go"
   packages = ["."]
@@ -51,12 +95,28 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
+[[projects]]
   branch = "master"
   digest = "1:2f9538da7381bb981fb8451b2b0fb304c2bc7f1724228dc336a8f002e6fec704"
   name = "github.com/xtgo/uuid"
   packages = ["."]
   pruneopts = "UT"
   revision = "a0b114877d4caeffbd7f87e3757c17fce570fea7"
+
+[[projects]]
+  digest = "1:aa7ab4fd27851221e4153921472ef7e3c1b048eaacca8e87c73fb7a094250dd7"
+  name = "github.com/zorkian/go-datadog-api"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f3f6d2f4859047aae0cac1ce3d16689608480fd9"
+  version = "v2.18.0"
 
 [[projects]]
   digest = "1:dad6cd59e8bb8d209194efbd3850b5d054384a63061671bfc2a6b2cc0929c731"
@@ -89,10 +149,15 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/FindHotel/meta/pkg/log",
+    "github.com/FindHotel/meta/pkg/reports",
+    "github.com/rcrowley/go-metrics",
     "github.com/segmentio/analytics-go",
     "github.com/segmentio/backo-go",
     "github.com/segmentio/conf",
+    "github.com/stretchr/testify/assert",
     "github.com/xtgo/uuid",
+    "github.com/zorkian/go-datadog-api",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,3 +44,11 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/rcrowley/go-metrics"
+
+[[constraint]]
+  name = "github.com/zorkian/go-datadog-api"
+  version = "2.18.0"

--- a/Readme.md
+++ b/Readme.md
@@ -1,20 +1,21 @@
-# analytics-go [![Circle CI](https://circleci.com/gh/segmentio/analytics-go/tree/master.svg?style=shield)](https://circleci.com/gh/segmentio/analytics-go/tree/master) [![go-doc](https://godoc.org/github.com/segmentio/analytics-go?status.svg)](https://godoc.org/github.com/segmentio/analytics-go)
+# analytics-go [![go-doc](https://godoc.org/github.com/FindHotel/analytics-go?status.svg)](https://godoc.org/github.com/FindHotel/analytics-go)
 
 Segment analytics client for Go.
 
 This is a fork of [segmentio/analytics-go](https://github.com/segmentio/analytics-go) library.
- 
+
 Notable changes:
- 
+
 - Use fully customised endpoint without `/v1/batch` postfix
 - Use `X-API-Key` header for authorisation
- 
+- Ability to report usage metrics to DataDog
+
 Latest stable branch is [fh/master](https://github.com/FindHotel/analytics-go/tree/fh/master). Releases are presented on [Releases page](https://github.com/FindHotel/analytics-go/releases).
 
 ## Installation
 
-If you use [dep](https://github.com/golang/dep) then add these lines into your `Gopkg.toml`:
-    
+If you use [dep](https://github.com/golang/dep) then add these lines to your `Gopkg.toml`:
+
     [[constraint]]
       name = "github.com/FindHotel/analytics-go"
       version = "3.1.0"
@@ -42,10 +43,16 @@ import (
 
 func main() {
     // Instantiates a client to use send messages to the segment API.
+
+    reporter := analytics.NewDatadogReporter(os.Getenv("DD_API_KEY"), os.Getenv("DD_APP_KEY"))
+    // if you don't need metrics use
+    // reporter := &analytics.DiscardReporter{}
+
     client, _ := analytics.NewWithConfig(
         os.Getenv("SEGMENT_WRITE_KEY"),
         analytics.Config{
             Endpoint: os.Getenv("SEGMENT_ENDPOINT"),
+            Reporter: reporter,
         },
     )
 

--- a/alias.go
+++ b/alias.go
@@ -1,6 +1,6 @@
 package analytics
 
-// This type represents object sent in a alias call as described in
+// Alias represents object sent in a alias call as described in
 // https://segment.com/docs/libraries/http/#alias
 type Alias struct {
 	// This field is exported for serialization purposes and shouldn't be set by

--- a/alias.go
+++ b/alias.go
@@ -15,6 +15,10 @@ type Alias struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Alias) tags() []string {
+	return []string{"type:" + msg.Type}
+}
+
 func (msg Alias) validate() error {
 	if len(msg.UserId) == 0 {
 		return FieldError{

--- a/analytics.go
+++ b/analytics.go
@@ -59,9 +59,19 @@ type client struct {
 	http http.Client
 }
 
-// Instantiate a new client that uses the write key passed as first argument to
-// send messages to the backend.
-// The client is created with the default configuration.
+// NewDiscardClient returns client which discards all messages.
+func NewDiscardClient() Client {
+	return discardClient{}
+}
+
+type discardClient struct{}
+
+func (c discardClient) Close() error          { return nil }
+func (c discardClient) Enqueue(Message) error { return nil }
+
+// New instantiates a new client that uses the write key passed as first
+// argument to send messages to the backend. The client is created with the
+// default (empty) configuration.
 func New(writeKey string) Client {
 	// Here we can ignore the error because the default config is always valid.
 	c, _ := NewWithConfig(writeKey, Config{})

--- a/analytics.go
+++ b/analytics.go
@@ -1,19 +1,18 @@
 package analytics
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"sync"
-
-	"bytes"
-	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // Version of the client.
-const Version = "3.0.0"
+const Version = "3.2.0"
 
 // This interface is the main API exposed by the analytics package.
 // Values that satsify this interface are returned by the client constructors

--- a/analytics.go
+++ b/analytics.go
@@ -116,6 +116,7 @@ func makeHttpClient(transport http.RoundTripper) http.Client {
 
 func (c *client) Enqueue(msg Message) (err error) {
 	if err = msg.validate(); err != nil {
+		droppedCounters(msg.tags()...).Inc(1)
 		return
 	}
 
@@ -166,6 +167,7 @@ func (c *client) Enqueue(msg Message) (err error) {
 		// and instead report that the client has been closed and shouldn't be
 		// used anymore.
 		if recover() != nil {
+			droppedCounters(msg.tags()...).Inc(1)
 			err = ErrClosed
 		}
 	}()

--- a/config.go
+++ b/config.go
@@ -157,6 +157,10 @@ func makeConfig(c Config) Config {
 		c.RetryAfter = backo.DefaultBacko().Duration
 	}
 
+	if c.Reporter == nil {
+		c.Reporter = &DiscardReporter{}
+	}
+
 	if c.uid == nil {
 		c.uid = uid
 	}

--- a/config.go
+++ b/config.go
@@ -61,6 +61,10 @@ type Config struct {
 	// If not set the client will fallback to use a default retry policy.
 	RetryAfter func(int) time.Duration
 
+	// Reporter is used to report metrics to external reporting system such
+	// as DataDog. Useful implementations are DataDog and LogReporter.
+	Reporter Reporter
+
 	// A function called by the client to generate unique message identifiers.
 	// The client uses a UUID generator if none is provided.
 	// This field is not exported and only exposed internally to let unit tests
@@ -108,6 +112,14 @@ func (c *Config) validate() error {
 			Reason: "negative batch sizes are not supported",
 			Field:  "BatchSize",
 			Value:  c.BatchSize,
+		}
+	}
+
+	if c.Reporter == nil {
+		return ConfigError{
+			Reason: "reporter is not provided",
+			Field:  "Reporter",
+			Value:  c.Reporter,
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	RetryAfter func(int) time.Duration
 
 	// Reporter is used to report metrics to external reporting system such
-	// as DataDog. Useful implementations are DataDog and LogReporter.
+	// as DataDog. Useful implementations are DatadogReporter and LogReporter.
 	Reporter Reporter
 
 	// A function called by the client to generate unique message identifiers.

--- a/group.go
+++ b/group.go
@@ -17,6 +17,10 @@ type Group struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Group) tags() []string {
+	return []string{"type:" + msg.Type}
+}
+
 func (msg Group) validate() error {
 	if len(msg.GroupId) == 0 {
 		return FieldError{

--- a/group.go
+++ b/group.go
@@ -1,6 +1,6 @@
 package analytics
 
-// This type represents object sent in a group call as described in
+// Group represents object sent in a group call as described in
 // https://segment.com/docs/libraries/http/#group
 type Group struct {
 	// This field is exported for serialization purposes and shouldn't be set by

--- a/identify.go
+++ b/identify.go
@@ -16,6 +16,10 @@ type Identify struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Identify) tags() []string {
+	return []string{"type:" + msg.Type}
+}
+
 func (msg Identify) validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/message.go
+++ b/message.go
@@ -33,6 +33,9 @@ type Callback interface {
 // and therefore can be passed to the analytics.Client.Send method.
 type Message interface {
 
+	// Returns tags associated with the message.
+	tags() []string
+
 	// Validates the internal structure of the message, the method must return
 	// nil if the message is valid, or an error describing what went wrong.
 	validate() error

--- a/page.go
+++ b/page.go
@@ -17,6 +17,10 @@ type Page struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Page) tags() []string {
+	return []string{"type:" + msg.Type}
+}
+
 func (msg Page) validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/report.go
+++ b/report.go
@@ -61,6 +61,15 @@ var hostname = func() string {
 	return h
 }()
 
+// DiscardReporter discards all metrics, useful for tests.
+type DiscardReporter struct{}
+
+// Report reports metrics.
+func (r DiscardReporter) Report(metricName string, value interface{}, tags []string, ts time.Time) {}
+
+// AddTags adds tags to be added to each metric reported.
+func (r *DiscardReporter) AddTags(tags []string) {}
+
 // LogReporter report metrics as a log.
 type LogReporter struct {
 	Logger Logger

--- a/report.go
+++ b/report.go
@@ -74,14 +74,24 @@ func (r *DiscardReporter) AddTags(tags []string) {}
 
 // LogReporter report metrics as a log.
 type LogReporter struct {
-	Logger Logger
+	logger Logger
 	tags   []string
+}
+
+func NewLogReporter(l Logger) *LogReporter {
+	if l == nil {
+		l = newDefaultLogger()
+	}
+	return &LogReporter{
+		logger: l,
+		tags:   []string{},
+	}
 }
 
 // Report reports metrics.
 func (r LogReporter) Report(metricName string, value interface{}, tags []string, ts time.Time) {
 	allTags := append(tags, r.tags...)
-	r.Logger.Logf("%s[%s] = %v", metricName, strings.Join(allTags, ", "), value)
+	r.logger.Logf("%s[%s] = %v", metricName, strings.Join(allTags, ", "), value)
 }
 
 // AddTags adds tags to be added to each metric reported.
@@ -200,6 +210,9 @@ func newCounters(name string) func(tags ...string) metrics.Counter {
 
 func (c *client) loopMetrics() {
 	var reporter = c.Config.Reporter
+	if reporter == nil {
+		panic("configured reporter is nil")
+	}
 	reporter.AddTags([]string{
 		"key:" + c.key,
 		"endpoint:" + c.Config.Endpoint,

--- a/report.go
+++ b/report.go
@@ -1,0 +1,216 @@
+package analytics
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	metrics "github.com/rcrowley/go-metrics"
+	datadog "github.com/zorkian/go-datadog-api"
+)
+
+var successCounters = newCounters("success")
+var failureCounters = newCounters("failure")
+
+// Reporter provides a function to reporting metrics.
+type Reporter interface {
+	Report(metricName string, value interface{}, tags []string, ts time.Time)
+	AddTags(tags []string)
+}
+
+func splitTags(name string) (string, []string) {
+	tokens := strings.Split(name, ".")
+	if len(tokens) <= 1 {
+		return name, []string{}
+	}
+	names := []string{}
+	tags := []string{}
+	for _, token := range tokens {
+		if strings.Contains(token, ":") {
+			tags = append(tags, token)
+		} else {
+			names = append(names, token)
+		}
+	}
+	return strings.Join(names, "."), tags
+}
+
+func reportAll(prefix string, r Reporter) {
+	ts := time.Now()
+	metrics := metrics.DefaultRegistry.GetAll()
+	go func() {
+		for key, metric := range metrics {
+			for measure, value := range metric {
+				name, tags := splitTags(key)
+				name = prefix + "." + name
+				r.Report(name+"."+measure, value, tags, ts)
+			}
+		}
+	}()
+}
+
+var hostname = func() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "localhost"
+	}
+	return h
+}()
+
+var environment = os.Getenv("ENVIRONMENT")
+
+// LogReporter report metrics as a log.
+type LogReporter struct {
+	Logger Logger
+	tags   []string
+}
+
+// Report reports metrics.
+func (r LogReporter) Report(metricName string, value interface{}, tags []string, ts time.Time) {
+	allTags := append(tags, r.tags...)
+	r.Logger.Logf("%s[%s] = %v", metricName, strings.Join(allTags, ", "), value)
+}
+
+// AddTags adds tags to be added to each metric reported.
+func (r *LogReporter) AddTags(tags []string) {
+	r.tags = tags
+}
+
+// NewDatadogReporter is a factory method to create DataDog reporter
+// with sane defaults.
+func NewDatadogReporter(apiKey, appKey string) *DatadogReporter {
+	dr := DatadogReporter{
+		Client: datadog.NewClient(apiKey, appKey),
+	}
+	dr.Client.HttpClient = &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 30 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 30 * time.Second,
+		},
+	}
+	dr.logger = newDefaultLogger()
+	dr.tags = []string{"transport:http", "sdk:go"}
+	return &dr
+}
+
+// WithLogger sets logger to DatadogReporter.
+func (dd *DatadogReporter) WithLogger(logger Logger) *DatadogReporter {
+	dd.logger = logger
+	return dd
+}
+
+// DatadogReporter reports metrics to DataDog.
+type DatadogReporter struct {
+	Client *datadog.Client
+	logger Logger
+	tags   []string
+}
+
+// AddTags adds tags to be added to each metric reported.
+func (dd *DatadogReporter) AddTags(tags []string) {
+	dd.tags = append(dd.tags, tags...)
+}
+
+var once sync.Once
+
+// Report sends provided metric to Datadog.
+func (dd DatadogReporter) Report(metricName string, value interface{}, tags []string, ts time.Time) {
+	if environment == "" {
+		once.Do(func() {
+			dd.logger.Errorf("Not sending metrics as ENVIRONMENT is empty")
+		})
+		return
+	}
+
+	metricType := "gauge"
+	metricValue, err := func() (float64, error) {
+		switch v := value.(type) {
+		case float64:
+			return v, nil
+		case int64:
+			return float64(v), nil
+		case int:
+			return float64(v), nil
+		}
+		return 0, fmt.Errorf("can't handle value %+v", value)
+	}()
+	if err != nil {
+		dd.logger.Errorf("Serializing value for metric %s(%+v) failed: %s", metricName, value, err)
+		return
+	}
+	metricTimestamp := float64(ts.Truncate(time.Minute).Unix())
+	allTags := append(tags, "environment:"+environment, "hostname:"+hostname)
+	allTags = append(allTags, dd.tags...)
+	metric := datadog.Metric{
+		Metric: &metricName,
+		Type:   &metricType,
+		Tags:   allTags,
+		Points: []datadog.DataPoint{{&metricTimestamp, &metricValue}},
+	}
+
+	if err := dd.Client.PostMetrics([]datadog.Metric{metric}); err != nil {
+		dd.logger.Errorf("Reporting metrics failed: %s", err)
+	}
+}
+
+func resetMetrics() {
+	registry := metrics.DefaultRegistry
+	for name := range registry.GetAll() {
+		metric := registry.Get(name)
+		switch m := metric.(type) {
+		case metrics.Counter:
+			m.Clear()
+		case metrics.Gauge:
+			m.Update(0)
+		case metrics.Histogram:
+			// do nothing as Histogram has it's own internal cleanup
+		}
+	}
+}
+
+// newCounters returns factory for tagged counters.
+func newCounters(name string) func(tags ...string) metrics.Counter {
+	counters := make(map[string]metrics.Counter)
+	mu := &sync.Mutex{}
+
+	return func(tags ...string) metrics.Counter {
+		fullName := strings.Join(append([]string{name}, tags...), ".")
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		counter, ok := counters[fullName]
+		if !ok {
+			counter = metrics.GetOrRegister(
+				fullName,
+				metrics.NewCounter(),
+			).(metrics.Counter)
+			counters[fullName] = counter
+		}
+		return counter
+	}
+}
+
+func (c *client) loopMetrics() {
+	var reporter = c.Config.Reporter
+	if os.Getenv("ENVIRONMENT") == "" {
+		c.Config.Logger.Logf("Using reports.LogReporter for metrics")
+		reporter = &LogReporter{}
+	}
+	reporter.AddTags([]string{
+		"key:" + c.key,
+		"endpoint:" + c.Config.Endpoint,
+	})
+
+	for range time.Tick(60 * time.Second) {
+		reportAll("evas.submitted", reporter)
+		resetMetrics()
+	}
+}

--- a/report.go
+++ b/report.go
@@ -39,9 +39,11 @@ func splitTags(name string) (string, []string) {
 	return strings.Join(names, "."), tags
 }
 
+var metricsRegistry = metrics.NewRegistry()
+
 func reportAll(prefix string, r Reporter) {
 	ts := time.Now()
-	metrics := metrics.DefaultRegistry.GetAll()
+	metrics := metricsRegistry.GetAll()
 	go func() {
 		for key, metric := range metrics {
 			for measure, value := range metric {
@@ -186,7 +188,7 @@ func newCounters(name string) func(tags ...string) metrics.Counter {
 
 		counter, ok := counters[fullName]
 		if !ok {
-			counter = metrics.GetOrRegister(
+			counter = metricsRegistry.GetOrRegister(
 				fullName,
 				metrics.NewCounter(),
 			).(metrics.Counter)

--- a/report.go
+++ b/report.go
@@ -213,9 +213,11 @@ func (c *client) loopMetrics() {
 	if reporter == nil {
 		panic("configured reporter is nil")
 	}
+
+	ep := strings.Split(c.Config.Endpoint, "/")
 	reporter.AddTags([]string{
-		"key:" + c.key,
-		"endpoint:" + c.Config.Endpoint,
+		"key:" + fmt.Sprintf("%.6s", c.key),
+		"endpoint:" + fmt.Sprintf("%.9s", ep[len(ep)-1]),
 	})
 
 	for range time.Tick(60 * time.Second) {

--- a/report.go
+++ b/report.go
@@ -110,6 +110,7 @@ func NewDatadogReporter(apiKey, appKey string) *DatadogReporter {
 	dr.Client.HttpClient = &http.Client{
 		Timeout: time.Second * 30,
 		Transport: &http.Transport{
+			DisableKeepAlives: true,
 			Dial: (&net.Dialer{
 				Timeout: 30 * time.Second,
 			}).Dial,

--- a/screen.go
+++ b/screen.go
@@ -17,6 +17,10 @@ type Screen struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Screen) tags() []string {
+	return []string{"type:" + msg.Type}
+}
+
 func (msg Screen) validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/track.go
+++ b/track.go
@@ -17,6 +17,10 @@ type Track struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
+func (msg Track) tags() []string {
+	return []string{"type:" + msg.Type, "event:" + msg.Event}
+}
+
 func (msg Track) validate() error {
 	if len(msg.Event) == 0 {
 		return FieldError{


### PR DESCRIPTION
Introduces `Reporter` into the configuration, which is able to send metrics to an external system. One useful implementation of Reporter is DatadogReporter, which sends metrics to DataDog.