### PR TITLE
Add S3 transport

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,51 @@
   version = "v2.1.0"
 
 [[projects]]
+  digest = "1:9874425f935d8483b5fc9b7b2c6d7d57305521565899b9b498f7bdf413abc329"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sts",
+  ]
+  pruneopts = "UT"
+  revision = "f778816ebd8f4a83264c207c77e6bcd0a5a76603"
+  version = "v1.19.1"
+
+[[projects]]
   digest = "1:553f73a4171c265045ae4f5d3122429ecf2c9c0c232c91f336127fe45480104a"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
@@ -18,20 +63,19 @@
   version = "v2.1.0"
 
 [[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
+
+[[projects]]
   branch = "master"
   digest = "1:d38f81081a389f1466ec98192cf9115a82158854d6f01e1c23e2e7554b97db71"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
   pruneopts = "UT"
   revision = "3113b8401b8a98917cde58f8bbd42a1b1c03b1fd"
-
-[[projects]]
-  digest = "1:e271becdebd3dd7c004d7977a15ebdd1f4fa19f2fa7122d13e1116e9444a3190"
-  name = "github.com/segmentio/analytics-go"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "1178b964a36694a8f9c161b19e6fe28cb37e8482"
-  version = "v3.0.0"
 
 [[projects]]
   branch = "master"
@@ -122,8 +166,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/avast/retry-go",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/s3/s3manager",
     "github.com/rcrowley/go-metrics",
-    "github.com/segmentio/analytics-go",
     "github.com/segmentio/backo-go",
     "github.com/segmentio/conf",
     "github.com/xtgo/uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,3 +25,7 @@
 [[constraint]]
   name = "github.com/avast/retry-go"
   version = "2.1.0"
+
+[[constraint]]
+  name = "github.com/aws/aws-sdk-go"
+  version = "1.19.1"

--- a/analytics.go
+++ b/analytics.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version of the client.
-const Version = "3.4.1"
+const Version = "3.5.0"
 
 // Client is the main API exposed by the analytics package.
 // Values that satsify this interface are returned by the client constructors

--- a/logger.go
+++ b/logger.go
@@ -44,3 +44,12 @@ func (l stdLogger) Errorf(format string, args ...interface{}) {
 func newDefaultLogger() Logger {
 	return StdLogger(log.New(os.Stderr, "segment ", log.LstdFlags))
 }
+
+// DiscardLogger discards all log messages supplied to it.
+type DiscardLogger struct{}
+
+// Logf does nothing for DiscardLogger.
+func (l DiscardLogger) Logf(format string, args ...interface{}) {}
+
+// Errorf does nothing for DiscardLogger.
+func (l DiscardLogger) Errorf(format string, args ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -5,8 +5,7 @@ import (
 	"os"
 )
 
-// Instances of types implementing this interface can be used to define where
-// the analytics client logs are written.
+// Logger can be used to define where the analytics client logs are written.
 type Logger interface {
 
 	// Analytics clients call this method to log regular messages about the
@@ -22,7 +21,7 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 }
 
-// This function instantiate an object that statisfies the analytics.Logger
+// StdLogger instantiate an object that statisfies the analytics.Logger
 // interface and send logs to standard logger passed as argument.
 func StdLogger(logger *log.Logger) Logger {
 	return stdLogger{

--- a/message.go
+++ b/message.go
@@ -82,6 +82,11 @@ func (m *serializedMessage) Msg() Message {
 	return m.msg
 }
 
+func (m *serializedMessage) size() int {
+	// The `+ 1` is for the comma that sits between each items of a JSON array.
+	return len(m.json) + 1
+}
+
 type message interface {
 	MarshalJSON() ([]byte, error)
 	Msg() Message
@@ -99,11 +104,6 @@ func makeMessage(m Message, maxBytes int) (message, error) {
 	}
 	result.json = b
 	return result, nil
-}
-
-func (m *serializedMessage) size() int {
-	// The `+ 1` is for the comma that sits between each items of a JSON array.
-	return len(m.json) + 1
 }
 
 type messageQueue struct {

--- a/message.go
+++ b/message.go
@@ -43,7 +43,7 @@ type Message interface {
 
 // Takes a message id as first argument and returns it, unless it's the zero-
 // value, in that case the default id passed as second argument is returned.
-func makeMessageId(id string, def string) string {
+func makeMessageID(id string, def string) string {
 	if len(id) == 0 {
 		return def
 	}
@@ -63,33 +63,45 @@ func makeTimestamp(t Time, def Time) Time {
 // export this type because it's only meant to be used internally to send groups
 // of messages in one API call.
 type batch struct {
-	MessageId string    `json:"messageId"`
+	MessageID string    `json:"messageId"`
 	SentAt    Time      `json:"sentAt"`
 	Messages  []message `json:"batch"`
 	Context   *Context  `json:"context"`
 }
 
-type message struct {
+type serializedMessage struct {
 	msg  Message
 	json []byte
 }
 
-func makeMessage(m Message, maxBytes int) (msg message, err error) {
-	if msg.json, err = json.Marshal(m); err == nil {
-		if len(msg.json) > maxBytes {
-			err = ErrMessageTooBig
-		} else {
-			msg.msg = m
-		}
-	}
-	return
-}
-
-func (m message) MarshalJSON() ([]byte, error) {
+func (m *serializedMessage) MarshalJSON() ([]byte, error) {
 	return m.json, nil
 }
 
-func (m message) size() int {
+func (m *serializedMessage) Msg() Message {
+	return m.msg
+}
+
+type message interface {
+	MarshalJSON() ([]byte, error)
+	Msg() Message
+	size() int
+}
+
+func makeMessage(m Message, maxBytes int) (message, error) {
+	result := &serializedMessage{msg: m}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return result, err
+	}
+	if len(b) > maxBytes {
+		return result, ErrMessageTooBig
+	}
+	result.json = b
+	return result, nil
+}
+
+func (m *serializedMessage) size() int {
 	// The `+ 1` is for the comma that sits between each items of a JSON array.
 	return len(m.json) + 1
 }
@@ -111,7 +123,7 @@ func (q *messageQueue) push(m message) (b []message) {
 	}
 
 	q.pending = append(q.pending, m)
-	q.bytes += len(m.json)
+	q.bytes += m.size()
 
 	if b == nil && len(q.pending) == q.maxBatchSize {
 		b = q.flush()

--- a/message_test.go
+++ b/message_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestMessageIdDefault(t *testing.T) {
-	if id := makeMessageId("", "42"); id != "42" {
+	if id := makeMessageID("", "42"); id != "42" {
 		t.Error("invalid default message id:", id)
 	}
 }
 
 func TestMessageIdNonDefault(t *testing.T) {
-	if id := makeMessageId("A", "42"); id != "A" {
+	if id := makeMessageID("A", "42"); id != "A" {
 		t.Error("invalid non-default message id:", id)
 	}
 }
@@ -55,7 +55,7 @@ func TestMessageQueuePushMaxBatchBytes(t *testing.T) {
 
 	q := messageQueue{
 		maxBatchSize:  100,
-		maxBatchBytes: len(m0.json) + 1,
+		maxBatchBytes: m0.size(),
 	}
 
 	if msgs := q.push(m0); msgs != nil {
@@ -76,12 +76,11 @@ func TestMakeMessage(t *testing.T) {
 
 	if msg, err := makeMessage(track, maxMessageBytes); err != nil {
 		t.Error("failed to make message from track message:", err)
-
-	} else if !reflect.DeepEqual(msg, message{
+	} else if !reflect.DeepEqual(msg.(*serializedMessage), &serializedMessage{
 		msg:  track,
 		json: []byte(`{"userId":"1","event":"","timestamp":0}`),
 	}) {
-		t.Error("invalid message generated from track message:", msg.msg, string(msg.json))
+		t.Error("invalid message generated from track message:", msg.Msg())
 	}
 }
 

--- a/report.go
+++ b/report.go
@@ -126,7 +126,7 @@ func newHTTPTransport() *http.Transport {
 
 // NewDatadogReporter is a factory method to create Datadog reporter
 // with sane defaults.
-func NewDatadogReporter(apiKey, appKey string) *DatadogReporter {
+func NewDatadogReporter(apiKey, appKey string, tags ...string) *DatadogReporter {
 	dr := DatadogReporter{
 		Client: datadog.NewClient(apiKey, appKey),
 		Mutex:  &sync.Mutex{},
@@ -136,7 +136,7 @@ func NewDatadogReporter(apiKey, appKey string) *DatadogReporter {
 		Transport: newHTTPTransport(),
 	}
 	dr.logger = newDefaultLogger()
-	dr.tags = []string{"transport:http", "sdkversion:go-" + Version}
+	dr.tags = append(tags, "transport:http", "sdkversion:go-"+Version)
 	return &dr
 }
 

--- a/s3client.go
+++ b/s3client.go
@@ -29,6 +29,8 @@ type S3 struct {
 	// tuna, salmon, haring, etc. Each system receives its own stream.
 	Stream string
 
+	MaxBatchBytes int
+
 	KeyConstructor func(now func() Time, uid func() string) string
 
 	UploaderOptions []func(*s3manager.Uploader)
@@ -87,7 +89,7 @@ func (c *s3Client) loop() {
 
 	mq := messageQueue{
 		maxBatchSize:  c.BatchSize,
-		maxBatchBytes: c.maxBatchBytes(),
+		maxBatchBytes: c.config.S3.MaxBatchBytes,
 	}
 
 	for {

--- a/s3client.go
+++ b/s3client.go
@@ -22,8 +22,9 @@ type s3Client struct {
 
 // S3 is a configuration for s3Client.
 type S3 struct {
-	Bucket string
-	Stage  string
+	Bucket             string
+	Stage              string
+	FullControlGrantee *string
 
 	// Stream is a name of the stream where messages will be delivered. Examples:
 	// tuna, salmon, haring, etc. Each system receives its own stream.
@@ -278,9 +279,10 @@ func (c *s3Client) upload(r io.Reader) error {
 	c.debugf("uploading to s3://%s/%s", c.config.S3.Bucket, key)
 
 	input := &s3manager.UploadInput{
-		Body:   r,
-		Bucket: &(c.config.S3.Bucket),
-		Key:    &key,
+		Body:             r,
+		Bucket:           &(c.config.S3.Bucket),
+		GrantFullControl: c.config.S3.FullControlGrantee,
+		Key:              &key,
 	}
 	_, err := c.uploader.Upload(input)
 	return err

--- a/s3client.go
+++ b/s3client.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 type s3Client struct {
 	*client
 	apiContext *apiContext
+	uploader   *s3manager.Uploader
 }
 
 // S3ClientConfig provides configuration for S3 Client.
@@ -25,6 +29,9 @@ func NewS3ClientWithConfig(writeKey string, config S3ClientConfig) (Client, erro
 		return nil, err
 	}
 
+	sess := session.Must(session.NewSession())
+	uploader := s3manager.NewUploader(sess)
+
 	c := &s3Client{
 		client: client,
 		apiContext: &apiContext{
@@ -32,6 +39,7 @@ func NewS3ClientWithConfig(writeKey string, config S3ClientConfig) (Client, erro
 				APIKey: writeKey,
 			},
 		},
+		uploader: uploader,
 	}
 
 	go c.loop()        // custom implementation

--- a/s3client.go
+++ b/s3client.go
@@ -1,0 +1,243 @@
+package analytics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type s3Client struct {
+	*client
+	apiContext *apiContext
+}
+
+// S3ClientConfig provides configuration for S3 Client.
+type S3ClientConfig struct {
+}
+
+// NewS3ClientWithConfig creates S3 client from provided configuration.
+// Pass empty S3ClientConfig{} to use default config.
+func NewS3ClientWithConfig(writeKey string, config S3ClientConfig) (Client, error) {
+	client, err := newWithConfig(writeKey, Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &s3Client{
+		client: client,
+		apiContext: &apiContext{
+			Identity: identity{
+				APIKey: writeKey,
+			},
+		},
+	}
+
+	go c.loop()        // custom implementation
+	go c.loopMetrics() // reuse client's implementation
+
+	return c, nil
+}
+
+// a copy of client.loop() function.
+func (c *s3Client) loop() {
+	defer close(c.shutdown)
+
+	wg := &sync.WaitGroup{}
+	defer wg.Wait()
+
+	tick := time.NewTicker(c.Interval)
+	defer tick.Stop()
+
+	ex := newExecutor(1)
+	defer ex.close()
+
+	mq := messageQueue{
+		maxBatchSize:  c.BatchSize,
+		maxBatchBytes: c.maxBatchBytes(),
+	}
+
+	for {
+		select {
+		case msg := <-c.msgs:
+			c.push(&mq, msg, wg, ex)
+
+		case <-tick.C:
+			c.flush(&mq, wg, ex)
+
+		case <-c.quit:
+			c.debugf("exit requested – draining messages")
+
+			// Drain the msg channel, we have to close it first so no more
+			// messages can be pushed and otherwise the loop would never end.
+			close(c.msgs)
+			for msg := range c.msgs {
+				c.push(&mq, msg, wg, ex)
+			}
+
+			c.flush(&mq, wg, ex)
+			c.debugf("exit")
+			return
+		}
+	}
+}
+
+func (c *s3Client) push(q *messageQueue, m Message, wg *sync.WaitGroup, ex *executor) {
+	var msg message
+	var err error
+
+	if msg, err = makeTargetMessage(m, maxMessageBytes, c.apiContext, c.now); err != nil {
+		c.errorf("%s - %v", err, m)
+		c.notifyFailure([]message{msg}, err)
+		return
+	}
+
+	c.debugf("buffer (%d/%d) %v", len(q.pending), c.BatchSize, m)
+
+	if msgs := q.push(msg); msgs != nil {
+		c.debugf("exceeded messages batch limit with batch of %d messages – flushing", len(msgs))
+		c.sendAsync(msgs, wg, ex)
+	}
+}
+
+type identity struct {
+	APIKey    string `json:"apiKey,omitempty"`
+	Country   string `json:"country,omitempty"`
+	IsDesktop *bool  `json:"isDesktop,omitempty"`
+	IsMobile  *bool  `json:"isMobile,omitempty"`
+	IsTablet  *bool  `json:"isTablet,omitempty"`
+}
+type apiContext struct {
+	APIID        string   `json:"apiId,omitempty"`
+	HTTPMethod   string   `json:"httpMethod,omitempty"`
+	Identity     identity `json:"identity,omitempty"`
+	RequestID    string   `json:"requestId,omitempty"`
+	ResourceID   string   `json:"resourceId,omitempty"`
+	ResourceMeta string   `json:"resourceMeta,omitempty"`
+	ResourcePath string   `json:"resourcePath,omitempty"`
+	Stage        string   `json:"stage,omitempty"`
+}
+
+// targetMessage is a single non-batched message delivered to s3 in one row of json.
+type targetMessage struct {
+	APIContext *apiContext `json:"context,omitempty"`
+	Event      Message     `json:"event"`
+	SentAt     Time        `json:"sentAt"`
+	ReceivedAt Time        `json:"receivedAt"`
+
+	json []byte
+}
+
+func (m *targetMessage) MarshalJSON() ([]byte, error) {
+	return m.json, nil
+}
+
+func (m *targetMessage) Msg() Message {
+	return m.Event
+}
+
+func (m *targetMessage) size() int {
+	return len(m.json)
+}
+
+// makeTargetMessage constructs targetMessage instance.
+func makeTargetMessage(m Message, maxBytes int, apiContext *apiContext, now func() Time) (message, error) {
+	ts := now()
+	result := &targetMessage{
+		APIContext: apiContext,
+		Event:      m,
+		SentAt:     ts,
+		ReceivedAt: ts,
+	}
+	b, err := json.Marshal(struct{ *targetMessage }{result})
+	if err != nil {
+		return result, err
+	}
+	if len(b) > maxBytes {
+		return result, ErrMessageTooBig
+	}
+	result.json = b
+	return result, nil
+}
+
+// Asychronously send a batched requests.
+func (c *s3Client) sendAsync(msgs []message, wg *sync.WaitGroup, ex *executor) {
+	wg.Add(1)
+
+	if !ex.do(func() {
+		defer wg.Done()
+		defer func() {
+			// In case a bug is introduced in the send function that triggers
+			// a panic, we don't want this to ever crash the application so we
+			// catch it here and log it instead.
+			if err := recover(); err != nil {
+				c.errorf("panic - %s", err)
+			}
+		}()
+		c.send(msgs)
+	}) {
+		wg.Done()
+		c.errorf("sending messages failed - %s", ErrTooManyRequests)
+		c.notifyFailure(msgs, ErrTooManyRequests)
+	}
+}
+
+// Send batch request.
+func (c *s3Client) send(msgs []message) {
+	const attempts = 10
+	var err error
+
+	buf := &bytes.Buffer{}
+	encoder := json.NewEncoder(buf)
+
+	marshalledMessages := []message{}
+	failedMessages := []message{}
+	var lastError error
+
+	for _, m := range msgs {
+		err = encoder.Encode(m)
+		if err != nil {
+			failedMessages = append(failedMessages, m)
+			lastError = err
+		} else {
+			marshalledMessages = append(marshalledMessages, m)
+		}
+	}
+	if len(failedMessages) > 0 {
+		c.errorf("marshalling message - %s", lastError)
+		c.notifyFailure(failedMessages, lastError)
+	}
+
+	if buf.Len() == 0 || len(marshalledMessages) == 0 {
+		c.errorf("empty buffer, send is not possible")
+		return
+	}
+
+	b := buf.Bytes()
+
+	for i := 0; i != attempts; i++ {
+		if err = c.upload(b); err == nil {
+			c.notifySuccess(marshalledMessages)
+			return
+		}
+
+		// Wait for either a retry timeout or the client to be closed.
+		select {
+		case <-time.After(c.RetryAfter(i)):
+		case <-c.quit:
+			err = fmt.Errorf("%d messages dropped because they failed to be sent and the client was closed", len(msgs))
+			c.errorf(err.Error())
+			c.notifyFailure(marshalledMessages, err)
+			return
+		}
+	}
+
+	c.errorf("%d messages dropped because they failed to be sent after %d attempts", len(msgs), attempts)
+	c.notifyFailure(msgs, err)
+}
+
+// Upload batch to S3.
+func (c *s3Client) upload(b []byte) error {
+	return fmt.Errorf("not implemented")
+}

--- a/s3client.go
+++ b/s3client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -22,13 +23,11 @@ type s3Client struct {
 
 // S3 is a configuration for s3Client.
 type S3 struct {
-	Bucket             string
-	Stage              string
-	FullControlGrantee string
-	fullControlGrantee *string
+	Bucket string
+	Stage  string
 
-	// Stream is a name of the stream where messages will be delivered. Examples:
-	// tuna, salmon, haring, etc. Each system receives its own stream.
+	// Stream is an arbitrary name of the stream where messages will be delivered.
+	// Examples: tuna, salmon, haring, etc. Each system receives its own stream.
 	Stream string
 
 	MaxBatchBytes int
@@ -284,10 +283,10 @@ func (c *s3Client) upload(r io.Reader) error {
 	c.debugf("uploading to s3://%s/%s", c.config.S3.Bucket, key)
 
 	input := &s3manager.UploadInput{
-		Body:             r,
-		Bucket:           &(c.config.S3.Bucket),
-		GrantFullControl: c.config.S3.fullControlGrantee,
-		Key:              &key,
+		Body:   r,
+		Bucket: aws.String(c.config.S3.Bucket),
+		ACL:    aws.String("public-read"),
+		Key:    aws.String(key),
 	}
 	_, err := c.uploader.Upload(input)
 	return err

--- a/s3client.go
+++ b/s3client.go
@@ -30,6 +30,8 @@ type S3ClientConfig struct {
 	Stream string
 
 	KeyConstructor func(now func() Time, uid func() string) string
+
+	S3UploaderOptions []func(*s3manager.Uploader)
 }
 
 // NewS3ClientWithConfig creates S3 client from provided configuration.
@@ -46,7 +48,7 @@ func NewS3ClientWithConfig(s3cfg S3ClientConfig, cfg Config) (Client, error) {
 	}
 
 	sess := session.Must(session.NewSession())
-	uploader := s3manager.NewUploader(sess)
+	uploader := s3manager.NewUploader(sess, s3Config.S3UploaderOptions...)
 
 	c := &s3Client{
 		client: client,

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -33,8 +33,10 @@ func TestTargetMessageMarshalling(t *testing.T) {
 
 func TestS3Client(t *testing.T) {
 	c, err := NewS3ClientWithConfig(
-		"qwer",
-		S3ClientConfig{},
+		S3ClientConfig{
+			Stream: "tuna",
+			Stage:  "pavel",
+		},
 		Config{
 			Verbose: true,
 		},

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -31,7 +31,7 @@ func TestTargetMessageMarshalling(t *testing.T) {
 	}
 }
 
-func TestS3Client(t *testing.T) {
+func ManualTestS3Client(t *testing.T) {
 	c, err := NewS3ClientWithConfig(
 		S3ClientConfig{
 			Stream: "tuna",

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -32,14 +32,16 @@ func TestTargetMessageMarshalling(t *testing.T) {
 }
 
 func ManualTestS3Client(t *testing.T) {
+	bucketOwner := "11f16854eb99ae7c1626f833db7678228569cf9877fd7b183efb6ecef693d85d"
 	c, err := NewS3ClientWithConfig(
 		S3ClientConfig{
 			Config: Config{
 				Verbose: true,
 			},
 			S3: S3{
-				Stream: "tuna",
-				Stage:  "pavel",
+				Stream:             "tuna",
+				Stage:              "pavel",
+				FullControlGrantee: bucketOwner,
 			},
 		},
 	)

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -34,11 +34,13 @@ func TestTargetMessageMarshalling(t *testing.T) {
 func ManualTestS3Client(t *testing.T) {
 	c, err := NewS3ClientWithConfig(
 		S3ClientConfig{
-			Stream: "tuna",
-			Stage:  "pavel",
-		},
-		Config{
-			Verbose: true,
+			Config: Config{
+				Verbose: true,
+			},
+			S3: S3{
+				Stream: "tuna",
+				Stage:  "pavel",
+			},
 		},
 	)
 	if err != nil {

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -1,0 +1,64 @@
+package analytics
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTargetMessageMarshalling(t *testing.T) {
+	m := Track{
+		Event:  "FooBared",
+		UserId: "tuna",
+		Properties: map[string]interface{}{
+			"index": 1,
+			"qwer":  3424,
+		},
+	}
+	tm, err := makeTargetMessage(m, 10000, nil, func() Time { return Time{} })
+	if err != nil {
+		t.Error(err)
+	}
+	b, err := json.Marshal(tm)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("json: %s", string(b))
+
+	expected := `{"event":{"userId":"tuna","event":"FooBared","timestamp":0,"properties":{"index":1,"qwer":3424}},"sentAt":0,"receivedAt":0}`
+
+	if string(b) != expected {
+		t.Errorf("Expected: %s, Actual: %s", expected, string(b))
+	}
+}
+
+func TestS3Client(t *testing.T) {
+	c, err := NewS3ClientWithConfig(
+		"qwer",
+		S3ClientConfig{},
+		Config{
+			Verbose: true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		m := Track{
+			Event:  "FooBared",
+			UserId: "tuna",
+			Properties: map[string]interface{}{
+				"index": i,
+				"qwer":  3424,
+			},
+		}
+		if err := c.Enqueue(m); err != nil {
+			t.Error(err)
+		}
+	}
+	if err := c.Close(); err != nil {
+		t.Error(err)
+	}
+
+	t.FailNow()
+}

--- a/s3client_test.go
+++ b/s3client_test.go
@@ -32,16 +32,14 @@ func TestTargetMessageMarshalling(t *testing.T) {
 }
 
 func ManualTestS3Client(t *testing.T) {
-	bucketOwner := "11f16854eb99ae7c1626f833db7678228569cf9877fd7b183efb6ecef693d85d"
 	c, err := NewS3ClientWithConfig(
 		S3ClientConfig{
 			Config: Config{
 				Verbose: true,
 			},
 			S3: S3{
-				Stream:             "tuna",
-				Stage:              "pavel",
-				FullControlGrantee: bucketOwner,
+				Stream: "tuna",
+				Stage:  "pavel",
 			},
 		},
 	)

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -1,0 +1,19 @@
+package analytics
+
+import "fmt"
+
+// Given a config object as argument the function will set all zero-values to
+// their defaults and return the modified object.
+func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
+	if c.Stage == "" {
+		c.Stage = "prod"
+	}
+	if c.Bucket == "" {
+		c.Bucket = "fh-analytics-" + c.Stage
+	}
+	if c.Stream == "" {
+		return c, fmt.Errorf("Stream should be provided")
+	}
+
+	return c, nil
+}

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const MB = 1024 * 1024 * 1024
+
 // Given a config object as argument the function will set all zero-values to
 // their defaults and return the modified object.
 func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
@@ -15,6 +17,10 @@ func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
 	}
 	if c.S3.Stage == "" {
 		c.S3.Stage = "dev"
+	}
+
+	if c.S3.MaxBatchBytes == 0 {
+		c.S3.MaxBatchBytes = 128 * MB
 	}
 
 	if c.S3.Bucket == "" {

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -23,6 +23,11 @@ func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
 		c.S3.MaxBatchBytes = 128 * MB
 	}
 
+	if c.S3.FullControlGrantee != "" {
+		grantee := fmt.Sprintf(`id="%s"`, c.S3.FullControlGrantee)
+		c.S3.fullControlGrantee = &grantee
+	}
+
 	if c.S3.Bucket == "" {
 		c.S3.Bucket = "fh-analytics-" + c.S3.Stage
 	}

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -6,7 +6,8 @@ import (
 	"time"
 )
 
-const MB = 1024 * 1024 * 1024
+// MB is the number of bytes in one megabyte.
+const MB = 1024 * 1024
 
 // Given a config object as argument the function will set all zero-values to
 // their defaults and return the modified object.
@@ -21,11 +22,6 @@ func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
 
 	if c.S3.MaxBatchBytes == 0 {
 		c.S3.MaxBatchBytes = 128 * MB
-	}
-
-	if c.S3.FullControlGrantee != "" {
-		grantee := fmt.Sprintf(`id="%s"`, c.S3.FullControlGrantee)
-		c.S3.fullControlGrantee = &grantee
 	}
 
 	if c.S3.Bucket == "" {

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -1,18 +1,44 @@
 package analytics
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // Given a config object as argument the function will set all zero-values to
 // their defaults and return the modified object.
 func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
 	if c.Stage == "" {
-		c.Stage = "prod"
+		return c, fmt.Errorf("Stage should be provided - dev, prod, ci etc")
 	}
+	if c.Stage != strings.ToLower(c.Stage) {
+		return c, fmt.Errorf("Stage should be lowercased")
+	}
+
 	if c.Bucket == "" {
 		c.Bucket = "fh-analytics-" + c.Stage
 	}
+
 	if c.Stream == "" {
 		return c, fmt.Errorf("Stream should be provided")
+	}
+	if c.Stream != strings.ToLower(c.Stream) {
+		return c, fmt.Errorf("Stream should be lowercased")
+	}
+
+	if c.KeyConstructor == nil {
+		c.KeyConstructor = func(now func() Time, uid func() string) string {
+			ts := time.Time(now())
+			return fmt.Sprintf(
+				"analytics/%s/bulk/%s/json/%d/%02d/%02d/%02d/%d-%s.json.gz",
+				strings.ToUpper(c.Stage),
+				c.Stream,
+				ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
+				ts.Unix(),
+				uid(),
+			)
+		}
 	}
 
 	return c, nil

--- a/s3clientconfig.go
+++ b/s3clientconfig.go
@@ -9,31 +9,33 @@ import (
 // Given a config object as argument the function will set all zero-values to
 // their defaults and return the modified object.
 func makeS3ClientConfig(c S3ClientConfig) (S3ClientConfig, error) {
-	if c.Stage == "" {
-		return c, fmt.Errorf("Stage should be provided - dev, prod, ci etc")
-	}
-	if c.Stage != strings.ToLower(c.Stage) {
+	c.Config = makeConfig(c.Config)
+	if c.S3.Stage != strings.ToLower(c.S3.Stage) {
 		return c, fmt.Errorf("Stage should be lowercased")
 	}
-
-	if c.Bucket == "" {
-		c.Bucket = "fh-analytics-" + c.Stage
+	if c.S3.Stage == "" {
+		c.S3.Stage = "dev"
 	}
 
-	if c.Stream == "" {
-		return c, fmt.Errorf("Stream should be provided")
+	if c.S3.Bucket == "" {
+		c.S3.Bucket = "fh-analytics-" + c.S3.Stage
 	}
-	if c.Stream != strings.ToLower(c.Stream) {
+
+	if c.S3.Stream != strings.ToLower(c.S3.Stream) {
 		return c, fmt.Errorf("Stream should be lowercased")
 	}
 
-	if c.KeyConstructor == nil {
-		c.KeyConstructor = func(now func() Time, uid func() string) string {
+	if c.S3.Stream == "" {
+		c.S3.Stream = "haring"
+	}
+
+	if c.S3.KeyConstructor == nil {
+		c.S3.KeyConstructor = func(now func() Time, uid func() string) string {
 			ts := time.Time(now())
 			return fmt.Sprintf(
 				"analytics/%s/bulk/%s/json/%d/%02d/%02d/%02d/%d-%s.json.gz",
-				strings.ToUpper(c.Stage),
-				c.Stream,
+				strings.ToUpper(c.S3.Stage),
+				c.S3.Stream,
 				ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
 				ts.Unix(),
 				uid(),


### PR DESCRIPTION
Expenses for AWS API Gateway and Kinesis Firehose turned to be very high, so this PR adds `s3Client` which uploads events directly to S3.

Usage examples:

```go
package main

import (
    "os"

    analytics "github.com/FindHotel/analytics-go"
)

func main() {
    whaleClient, err := analytics.NewWithConfig(
        os.Getenv("SEGMENT_WRITE_KEY"),
        analytics.Config{
            Endpoint: os.Getenv("SEGMENT_ENDPOINT"),
        },
    )
    if err != nil { // ALWAYS check for errors!
        panic(err)
    }

    tunaClient, err := analytics.NewS3ClientWithConfig(analytics.S3ClientConfig{
	Config: analytics.Config{},
	S3: analytics.S3{
		Stage:  "dev",
		Stream: "tuna",
		},
	},
    })
    if err != nil { // ALWAYS check for errors!
        panic(err)
    }


    // This will go to whale stream
    whaleClient.Enqueue(analytics.Track{
        UserId: "test-user",
        Event:  "AvailabilityRequested",
    })

    // This will go to tuna stream
    tunaClient.Enqueue(analytics.Track{
        UserId: "test-user",
        Event:  "OfferFound",
    })

    // Flushes any queued messages and closes the client - DON'T forget this step.
    whaleClient.Close()
    tunaClient.Close()
}
```