### PR TITLE
recover from panic in analytics go 

### DIFF
--- a/report.go
+++ b/report.go
@@ -167,18 +167,6 @@ func (dd *DatadogReporter) Flush() error {
 	dd.metrics = []datadog.Metric{}
 	dd.Unlock()
 
-	defer func() {
-		if r := recover(); r != nil {
-			// state is unknown
-			// log the error and kill the application
-			dd.logger.Errorf("panic in analytics (%d metrics): %#v", len(metrics), r)
-			for i, m := range metrics {
-				dd.logger.Errorf("%d: %#v", i, m)
-			}
-			os.Exit(1)
-		}
-	}()
-
 	err := retry.Do(
 		func() error {
 			return dd.Client.PostMetrics(metrics)


### PR DESCRIPTION
there is a race condition that could result in the bug we are seeing
when running `reporter.Flush()` the metrics are assigned to a local variable (without a lock)
if during the same time, a `reporter.Report(..)` is called, it will append to the same slice of metrics, and could result in corrupted data

note:
in the analytics client, the `Report` and the `Flush` happen in the same go routine, so this shouldn't happen,
but in RAA, we are sharing the reporter between multiple clients, so it is possible to call both methods at the same time from different routines.