### PR TITLE
Remove useless error log message

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -300,7 +300,6 @@ func (c *client) upload(b []byte) error {
 	res, err := c.http.Do(req)
 
 	if err != nil {
-		c.errorf("sending request - %s", err)
 		return err
 	}
 


### PR DESCRIPTION
If the request fail, the request will be retried, if the retry fails, there is another error message.